### PR TITLE
In getChildDropdowns(), search for '.dropdown_nested' selector.

### DIFF
--- a/src/js/aria-dropdown.js
+++ b/src/js/aria-dropdown.js
@@ -83,11 +83,7 @@ SOFTWARE.
 
   //get all child dropdowns starting from a DOM element
   function getChildDropdowns(target, dataKey) {
-    while (target[0].tagName !== 'BODY' && target.data(dataKey) === undefined) {
-      target = target.parent();
-    }
-
-    var elements = target.find('*'),
+    var elements = target.find('.dropdown_nested'),
       elementsLength = elements.length,
       dropdowns = [];
 


### PR DESCRIPTION
@DavideTriso - `getChildDropdowns()` searches for child dropdowns of a menu.

On the [demo page,](https://davidetriso.github.io/aria-dropdown/) a child dropdown uses the CSS class `dropdown_nested` to denote a child dropdown, so maybe we can search for this class instead?

I'm not sure what this logic is referring to:
```
    while (target[0].tagName !== 'BODY' && target.data(dataKey) === undefined) {
      target = target.parent();
    }
```

I encountered a JS error where `target[0].tagName` might not be available, which is what led me to creating this pull request.

Let me know if you have any questions.